### PR TITLE
fix sargan_factorloadings_R2 in main file

### DIFF
--- a/R/EFAmiive5AllFunctions.R
+++ b/R/EFAmiive5AllFunctions.R
@@ -217,6 +217,7 @@ select_scalingind <- function(data, sigLevel = .05,
     mixedlist <- num_nonsigfactorloading[sarganallmin]
     mixedmin <- min(unlist(mixedlist))
     mixedallmin <- colnames(t(which(mixedlist==mixedmin)))
+    scalingindicator <- mixedallmin[order(match(mixedallmin, R2_order))][1]
 
   }
   if(scalingCrit == 'factorloading_R2'){


### PR DESCRIPTION
The function select_scalingind didn't work - had a missing line. I fixed by looking at the 'scalingindicatorselection' function (which is outside this main function file)